### PR TITLE
update the linking style for Sophus package

### DIFF
--- a/ch4/CMakeLists.txt
+++ b/ch4/CMakeLists.txt
@@ -3,10 +3,10 @@ project(useSophus)
 
 # 为使用 sophus，需要使用find_package命令找到它
 find_package(Sophus REQUIRED)
-include_directories(${Sophus_INCLUDE_DIRS})
 
 # Eigen
 include_directories("/usr/include/eigen3")
 add_executable(useSophus useSophus.cpp)
+target_link_libraries(useSophus Sophus::Sophus)
 
 add_subdirectory(example)


### PR DESCRIPTION
"Legacy style CMake variables such as `Sophus_INCLUDE_DIRS` are not defined by the Sophus package config anymore, since Dec 13, 2017."  
You need to link the target against the Sophus::Sophus.