### PR TITLE
Update ceresCurveFitting.cpp

### DIFF
--- a/ch6/ceresCurveFitting.cpp
+++ b/ch6/ceresCurveFitting.cpp
@@ -16,13 +16,15 @@ struct CURVE_FITTING_COST {
   // 残差的计算
   template<typename T>
   bool operator()(
-    const T *const abc, // 模型参数，有3维
+    const T *const a,  // 模型参数 a
+    const T *const b,  // 模型参数 b 
+    const T *const c,  // 模型参数 c
     T *residual) const {
-    residual[0] = T(_y) - ceres::exp(abc[0] * T(_x) * T(_x) + abc[1] * T(_x) + abc[2]); // y-exp(ax^2+bx+c)
+    residual[0] = T(_y) - ceres::exp(a[0] * T(_x) * T(_x) + b[0] * T(_x) + c[0]); // y-exp(ax^2+bx+c)
     return true;
   }
 
-  const double _x, _y;    // x,y数据
+  double _x, _y;    // x,y数据
 };
 
 int main(int argc, char **argv) {
@@ -37,21 +39,21 @@ int main(int argc, char **argv) {
   for (int i = 0; i < N; i++) {
     double x = i / 100.0;
     x_data.push_back(x);
-    y_data.push_back(exp(ar * x * x + br * x + cr) + rng.gaussian(w_sigma * w_sigma));
+    y_data.push_back(exp(ar * x * x + br * x + cr) + rng.gaussian(w_sigma));
   }
-
-  double abc[3] = {ae, be, ce};
 
   // 构建最小二乘问题
   ceres::Problem problem;
   for (int i = 0; i < N; i++) {
     problem.AddResidualBlock(     // 向问题中添加误差项
       // 使用自动求导，模板参数：误差类型，输出维度，输入维度，维数要与前面struct中一致
-      new ceres::AutoDiffCostFunction<CURVE_FITTING_COST, 1, 3>(
+      new ceres::AutoDiffCostFunction<CURVE_FITTING_COST, 1, 1, 1, 1>(
         new CURVE_FITTING_COST(x_data[i], y_data[i])
       ),
       nullptr,            // 核函数，这里不使用，为空
-      abc                 // 待估计参数
+      &ae,  // 待估计参数 a
+      &be,  // 待估计参数 b
+      &ce   // 待估计参数 c
     );
   }
 
@@ -70,7 +72,7 @@ int main(int argc, char **argv) {
   // 输出结果
   cout << summary.BriefReport() << endl;
   cout << "estimated a,b,c = ";
-  for (auto a:abc) cout << a << " ";
+  cout << ae << " " << be << " " << ce;
   cout << endl;
 
   return 0;


### PR DESCRIPTION
- Change the argument list of the operator, and modify the residual expression accordingly. We should pass a dimension parameter for **every parameter block**. See: http://ceres-solver.org/nnls_modeling.html#_CPPv2N5ceres20AutoDiffCostFunctionE

- Delete the double keyword in the data member of the struct. We should avoid using const non-static (data) member variables. See: https://www.reddit.com/r/cpp/comments/8wbeom/coding_guideline_avoid_const_member_variables/

- Change the parameter list of the **rng.gaussian** function. It accepts as the parameter a single sigma which will be converted to the variance counterpart implicitly.