### PR TITLE
Fix ch3 so buildable

### DIFF
--- a/ch4/CMakeLists.txt
+++ b/ch4/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 project(useSophus)
 
 # 为使用 sophus，需要使用find_package命令找到它

--- a/ch4/useSophus.cpp
+++ b/ch4/useSophus.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
   // 最后，演示一下更新
   Vector6d update_se3; //更新量
   update_se3.setZero();
-  update_se3(0, 0) = 1e-4d;
+  update_se3(0, 0) = 1e-4;
   Sophus::SE3d SE3_updated = Sophus::SE3d::exp(update_se3) * SE3_Rt;
   cout << "SE3 updated = " << endl << SE3_updated.matrix() << endl;
 


### PR DESCRIPTION
Fixes compilation for the Ch3 source

Without the CMake minimum version bump, we see this error when running `cmake ..`

```
$ cmake ..
-- The C compiler identification is Clang 9.0.0
-- The CXX compiler identification is Clang 9.0.0
-- Check for working C compiler: /usr/local/opt/llvm/bin/clang
-- Check for working C compiler: /usr/local/opt/llvm/bin/clang -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/local/opt/llvm/bin/clang++
-- Check for working CXX compiler: /usr/local/opt/llvm/bin/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
CMake Error in CMakeLists.txt:
  No known features for CXX compiler

  "Clang"

  version 9.0.0.


CMake Generate step failed.  Build files cannot be regenerated correctly.
```