### PR TITLE
ch5: fix joinMap compile error in ubuntu 20.04

### DIFF
--- a/ch5/rgbd/CMakeLists.txt
+++ b/ch5/rgbd/CMakeLists.txt
@@ -1,8 +1,13 @@
+option(USE_UBUNTU_20 "Set to ON if you are using Ubuntu 20.04" OFF)
 find_package(Sophus REQUIRED)
 include_directories(${Sophus_INCLUDE_DIRS})
 
 find_package(Pangolin REQUIRED)
-find_package(fmt REQUIRED)
+if(USE_UBUNTU_20)
+    message("You are using Ubuntu 20.04, fmt::fmt will be linked")
+    find_package(fmt REQUIRED)
+    set(FMT_LIBRARIES fmt::fmt)
+endif()
 
 add_executable(joinMap joinMap.cpp)
-target_link_libraries(joinMap ${OpenCV_LIBS} ${Pangolin_LIBRARIES} fmt::fmt)
+target_link_libraries(joinMap ${OpenCV_LIBS} ${Pangolin_LIBRARIES} ${FMT_LIBRARIES})

--- a/ch5/rgbd/CMakeLists.txt
+++ b/ch5/rgbd/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(Sophus REQUIRED)
 include_directories(${Sophus_INCLUDE_DIRS})
 
 find_package(Pangolin REQUIRED)
+find_package(fmt REQUIRED)
 
 add_executable(joinMap joinMap.cpp)
-target_link_libraries(joinMap ${OpenCV_LIBS} ${Pangolin_LIBRARIES})
+target_link_libraries(joinMap ${OpenCV_LIBS} ${Pangolin_LIBRARIES} fmt::fmt)

--- a/ch5/rgbd/joinMap.cpp
+++ b/ch5/rgbd/joinMap.cpp
@@ -2,8 +2,8 @@
 #include <fstream>
 #include <opencv2/opencv.hpp>
 #include <boost/format.hpp>  // for formating strings
-#include <sophus/se3.hpp>
 #include <pangolin/pangolin.h>
+#include <sophus/se3.hpp>
 
 using namespace std;
 typedef vector<Sophus::SE3d, Eigen::aligned_allocator<Sophus::SE3d>> TrajectoryType;
@@ -24,9 +24,9 @@ int main(int argc, char **argv) {
     }
 
     for (int i = 0; i < 5; i++) {
-        boost::format fmt("./%s/%d.%s"); //图像文件格式
-        colorImgs.push_back(cv::imread((fmt % "color" % (i + 1) % "png").str()));
-        depthImgs.push_back(cv::imread((fmt % "depth" % (i + 1) % "pgm").str(), -1)); // 使用-1读取原始图像
+        boost::format imgfmt("./%s/%d.%s"); //图像文件格式
+        colorImgs.push_back(cv::imread((imgfmt % "color" % (i + 1) % "png").str()));
+        depthImgs.push_back(cv::imread((imgfmt % "depth" % (i + 1) % "pgm").str(), -1)); // 使用-1读取原始图像
 
         double data[7] = {0};
         for (auto &d:data)


### PR DESCRIPTION
In Ubuntu 20.04, fmt is required. Also, the variable named `fmt` should be avoided:

- `pangolin/pangolin.h` has variable named `fmt`, so it should be included before `sophus/se3.hpp`. (This solves the error showed in my first commit message)
- change the variable named `fmt` to `imgfmt`