### PR TITLE
hotfix(ch8): fix bug related to opencv version

### DIFF
--- a/ch8/direct_method.cpp
+++ b/ch8/direct_method.cpp
@@ -203,7 +203,11 @@ void DirectPoseEstimationSingleLayer(
 
     // plot the projected pixels here
     cv::Mat img2_show;
+#if CV_VERSION_MAJOR < 4
     cv::cvtColor(img2, img2_show, CV_GRAY2BGR);
+#else
+    cv::cvtColor(img2, img2_show, cv::COLOR_GRAY2BGR);
+#endif
     VecVector2d projection = jaco_accu.projected_points();
     for (size_t i = 0; i < px_ref.size(); ++i) {
         auto p_ref = px_ref[i];

--- a/ch8/optical_flow.cpp
+++ b/ch8/optical_flow.cpp
@@ -142,7 +142,11 @@ int main(int argc, char **argv) {
 
     // plot the differences of those functions
     Mat img2_single;
+#if CV_VERSION_MAJOR < 4
     cv::cvtColor(img2, img2_single, CV_GRAY2BGR);
+#else
+    cv::cvtColor(img2, img2_single, cv::COLOR_GRAY2BGR);
+#endif
     for (int i = 0; i < kp2_single.size(); i++) {
         if (success_single[i]) {
             cv::circle(img2_single, kp2_single[i].pt, 2, cv::Scalar(0, 250, 0), 2);
@@ -151,7 +155,11 @@ int main(int argc, char **argv) {
     }
 
     Mat img2_multi;
+#if CV_VERSION_MAJOR < 4
     cv::cvtColor(img2, img2_multi, CV_GRAY2BGR);
+#else
+    cv::cvtColor(img2, img2_multi, cv::COLOR_GRAY2BGR);
+#endif
     for (int i = 0; i < kp2_multi.size(); i++) {
         if (success_multi[i]) {
             cv::circle(img2_multi, kp2_multi[i].pt, 2, cv::Scalar(0, 250, 0), 2);
@@ -160,7 +168,11 @@ int main(int argc, char **argv) {
     }
 
     Mat img2_CV;
+#if CV_VERSION_MAJOR < 4
     cv::cvtColor(img2, img2_CV, CV_GRAY2BGR);
+#else
+    cv::cvtColor(img2, img2_CV, cv::COLOR_GRAY2BGR);
+#endif
     for (int i = 0; i < pt2.size(); i++) {
         if (status[i]) {
             cv::circle(img2_CV, pt2[i], 2, cv::Scalar(0, 250, 0), 2);


### PR DESCRIPTION
the current examples require OpenCV 4, so CV_GRAY2BGR needs to be changed into OpenCV 4's compatible format cv::COLOR_GRAY2BGR