### PR TITLE
added ldconfig to Readme.txt

### DIFF
--- a/ch3/visualizeGeometry/Readme.txt
+++ b/ch3/visualizeGeometry/Readme.txt
@@ -12,6 +12,7 @@ cd build
 cmake ..
 make 
 sudo make install 
+ldconfig
 
 * compile this program:
 mkdir build


### PR DESCRIPTION
I started going through the exercises in the book. After compiling pangolin and following the instructions in the book I still couldn't detect the header from my cpp file. After running the command `ldconfig` it worked. I thought it may help someone to have that added into the instructions here as it took a bit of trouble shooting to figure out why it wasn't working. 