### PR TITLE
Update joinMap.cpp

### DIFF
--- a/ch5/rgbd/joinMap.cpp
+++ b/ch5/rgbd/joinMap.cpp
@@ -2,8 +2,9 @@
 #include <fstream>
 #include <opencv2/opencv.hpp>
 #include <boost/format.hpp>  // for formating strings
-#include <sophus/se3.hpp>
 #include <pangolin/pangolin.h>
+#include <sophus/se3.hpp>
+
 
 using namespace std;
 typedef vector<Sophus::SE3d, Eigen::aligned_allocator<Sophus::SE3d>> TrajectoryType;


### PR DESCRIPTION
for ubuntu20.04, the pangolin should be in front of sophus, since the fmt is relied by sophus while pangolin has "fmt" that is different from the library fmt.