### PR TITLE
修复 ch3 `examples/plotTrajectory.cpp` vector越界访问BUG

### DIFF
--- a/ch3/examples/plotTrajectory.cpp
+++ b/ch3/examples/plotTrajectory.cpp
@@ -76,10 +76,10 @@ void DrawTrajectory(vector<Isometry3d, Eigen::aligned_allocator<Isometry3d>> pos
       glEnd();
     }
     // 画出连线
-    for (size_t i = 0; i < poses.size(); i++) {
+    for (size_t i = 1U; i < poses.size(); i++) {
       glColor3f(0.0, 0.0, 0.0);
       glBegin(GL_LINES);
-      auto p1 = poses[i], p2 = poses[i + 1];
+      auto p1 = poses[i - 1U], p2 = poses[i];
       glVertex3d(p1.translation()[0], p1.translation()[1], p1.translation()[2]);
       glVertex3d(p2.translation()[0], p2.translation()[1], p2.translation()[2]);
       glEnd();


### PR DESCRIPTION
在ch3的 `examples/plotTrajectory.cpp` 的 [82 行](https://github.com/gaoxiang12/slambook2/blob/master/ch3/examples/plotTrajectory.cpp#L82):
```C++
    for (size_t i = 0; i < poses.size(); i++) {
      ...
      auto p1 = poses[i], p2 = poses[i + 1];
      ...
     }
```

对最后一个元素(i == poses.size() - 1U)迭代，用`[i + 1]`访问显然越界了，只是因为 `[]`操作符不检查range，且恰巧内存正常，所以程序没有崩溃。
对此，稍微修改了一点点，避免越界。 

> PS： 斗胆说下，一般建议用 `.at(idx)` 来做vector的访问，其显式做`out_of_range`的检查，可以避免很多因为越界访问导致的core-dump. 这里未做修改，保持代码风格一致。