### PR TITLE
Update CMakeList.txt in ch3/ that using Pangolin

### DIFF
--- a/ch3/examples/CMakeLists.txt
+++ b/ch3/examples/CMakeLists.txt
@@ -1,6 +1,8 @@
 include_directories("/usr/include/eigen3")
 add_executable(coordinateTransform coordinateTransform.cpp)
 
+set(CMAKE_CXX_FLAGS "-std=c++14")
+
 find_package(Pangolin REQUIRED)
 include_directories(${Pangolin_INCLUDE_DIRS})
 add_executable(plotTrajectory plotTrajectory.cpp)

--- a/ch3/visualizeGeometry/CMakeLists.txt
+++ b/ch3/visualizeGeometry/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required( VERSION 2.8 )
 project( visualizeGeometry )
 
-set(CMAKE_CXX_FLAGS "-std=c++11")
+# set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "-std=c++14")
 
 # 添加Eigen头文件
 include_directories( "/usr/include/eigen3" )


### PR DESCRIPTION
在Ubuntu 22.04 环境下，build操作会出现 `/usr/local/include/sigslot/signal.hpp` 报错，修改支持版本为 C++14 后错误消除：
```cpp
/usr/local/include/sigslot/signal.hpp:109:79: error: ‘decay_t’ is not a member of ‘std’; did you mean ‘decay’?
109 | constexpr bool is_weak_ptr_compatible_v = detail::is_weak_ptr_compatible<std::decay_t<P>>::value;
|                                                                               ^~~~~~~
|                                                                               decay
/usr/local/include/sigslot/signal.hpp:109:79: error: ‘decay_t’ is not a member of ‘std’; did you mean ‘decay’?
109 | constexpr bool is_weak_ptr_compatible_v = detail::is_weak_ptr_compatible<std::decay_t<P>>::value;
|                                                                               ^~~~~~~
|                                                                               decay
/usr/local/include/sigslot/signal.hpp:109:87: error: template argument 1 is invalid
109 | constexpr bool is_weak_ptr_compatible_v = detail::is_weak_ptr_compatible<std::decay_t<P>>::value;
|                                                                                       ^
/usr/local/include/sigslot/signal.hpp:109:92: error: ‘::value’ has not been declared
109 | constexpr bool is_weak_ptr_compatible_v = detail::is_weak_ptr_compatible<std::decay_t<P>>::value;
|                                                                                            ^~~~~
/usr/local/include/sigslot/signal.hpp:132:53: error: ‘remove_pointer_t’ is not a member of ‘std’; did you mean ‘remove_pointer’?
132 |                                                std::remove_pointer_t<T>>::value;
|                                                     ^~~~~~~~~~~~~~~~
|                                                     remove_pointer
/usr/local/include/sigslot/signal.hpp:132:53: error: ‘remove_pointer_t’ is not a member of ‘std’; did you mean ‘remove_pointer’?
132 |                                                std::remove_pointer_t<T>>::value;
|                                                     ^~~~~~~~~~~~~~~~
|                                                     remove_pointer
/usr/local/include/sigslot/signal.hpp:132:70: error: template argument 2 is invalid
132 |                                                std::remove_pointer_t<T>>::value;
|                                                                      ^
/usr/local/include/sigslot/signal.hpp:132:75: error: ‘::value’ has not been declared
132 |                                                std::remove_pointer_t<T>>::value;
|                                                                           ^~~~~
/usr/local/include/sigslot/signal.hpp:223:32: error: ‘enable_if_t’ is not a member of ‘std’
223 | struct function_traits<T, std::enable_if_t<trait::is_func_v<T>>> {
|                                ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:223:32: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:223:32: error: ‘enable_if_t’ is not a member of ‘std’
/usr/local/include/sigslot/signal.hpp:223:32: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:223:62: error: type/value mismatch at argument 2 in template parameter list for ‘template<class T, class> struct sigslot::detail::function_traits’
223 | struct function_traits<T, std::enable_if_t<trait::is_func_v<T>>> {
|                                                              ^~
/usr/local/include/sigslot/signal.hpp:223:62: note:   expected a type, got ‘(<expression error> < is_func_v<T>)’
/usr/local/include/sigslot/signal.hpp:223:64: error: expected unqualified-id before ‘>’ token
223 | struct function_traits<T, std::enable_if_t<trait::is_func_v<T>>> {
|                                                                ^
/usr/local/include/sigslot/signal.hpp:233:33: error: ‘enable_if_t’ is not a member of ‘std’
233 | struct function_traits<T*, std::enable_if_t<trait::is_func_v<T>>> {
|                                 ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:233:33: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:233:33: error: ‘enable_if_t’ is not a member of ‘std’
/usr/local/include/sigslot/signal.hpp:233:33: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:233:63: error: type/value mismatch at argument 2 in template parameter list for ‘template<class T, class> struct sigslot::detail::function_traits’
233 | struct function_traits<T*, std::enable_if_t<trait::is_func_v<T>>> {
|                                                               ^~
/usr/local/include/sigslot/signal.hpp:233:63: note:   expected a type, got ‘(<expression error> < is_func_v<T>)’
/usr/local/include/sigslot/signal.hpp:233:65: error: expected unqualified-id before ‘>’ token
233 | struct function_traits<T*, std::enable_if_t<trait::is_func_v<T>>> {
|                                                                 ^
/usr/local/include/sigslot/signal.hpp:243:32: error: ‘enable_if_t’ is not a member of ‘std’
243 | struct function_traits<T, std::enable_if_t<trait::is_pmf_v<T>>> {
|                                ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:243:32: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:243:32: error: ‘enable_if_t’ is not a member of ‘std’
/usr/local/include/sigslot/signal.hpp:243:32: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:243:61: error: type/value mismatch at argument 2 in template parameter list for ‘template<class T, class> struct sigslot::detail::function_traits’
243 | struct function_traits<T, std::enable_if_t<trait::is_pmf_v<T>>> {
|                                                             ^~
/usr/local/include/sigslot/signal.hpp:243:61: note:   expected a type, got ‘(<expression error> < is_pmf_v<T>)’
/usr/local/include/sigslot/signal.hpp:243:63: error: expected unqualified-id before ‘>’ token
243 | struct function_traits<T, std::enable_if_t<trait::is_pmf_v<T>>> {
|                                                               ^
/usr/local/include/sigslot/signal.hpp:254:32: error: ‘enable_if_t’ is not a member of ‘std’
254 | struct function_traits<T, std::enable_if_t<trait::has_call_operator_v<T>>> {
|                                ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:254:32: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:254:32: error: ‘enable_if_t’ is not a member of ‘std’
/usr/local/include/sigslot/signal.hpp:254:32: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:254:72: error: type/value mismatch at argument 2 in template parameter list for ‘template<class T, class> struct sigslot::detail::function_traits’
254 | struct function_traits<T, std::enable_if_t<trait::has_call_operator_v<T>>> {
|                                                                        ^~
/usr/local/include/sigslot/signal.hpp:254:72: note:   expected a type, got ‘(<expression error> < has_call_operator_v<T>)’
/usr/local/include/sigslot/signal.hpp:254:74: error: expected unqualified-id before ‘>’ token
254 | struct function_traits<T, std::enable_if_t<trait::has_call_operator_v<T>>> {
|                                                                          ^
/usr/local/include/sigslot/signal.hpp: In function ‘sigslot::detail::func_ptr sigslot::detail::get_function_ptr(const T&)’:
/usr/local/include/sigslot/signal.hpp:269:26: error: ‘decay_t’ is not a member of ‘std’; did you mean ‘decay’?
269 |     function_traits<std::decay_t<T>>::ptr(t, d);
|                          ^~~~~~~
|                          decay
/usr/local/include/sigslot/signal.hpp:269:26: error: ‘decay_t’ is not a member of ‘std’; did you mean ‘decay’?
269 |     function_traits<std::decay_t<T>>::ptr(t, d);
|                          ^~~~~~~
|                          decay
/usr/local/include/sigslot/signal.hpp:269:34: error: template argument 1 is invalid
269 |     function_traits<std::decay_t<T>>::ptr(t, d);
|                                  ^
/usr/local/include/sigslot/signal.hpp:269:35: error: expected unqualified-id before ‘>’ token
269 |     function_traits<std::decay_t<T>>::ptr(t, d);
|                                   ^~
/usr/local/include/sigslot/signal.hpp: At global scope:
/usr/local/include/sigslot/signal.hpp:291:32: error: ‘enable_if_t’ is not a member of ‘std’
291 | struct object_pointer<T*, std::enable_if_t<trait::is_pointer_v<T*>>> {
|                                ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:291:32: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:291:32: error: ‘enable_if_t’ is not a member of ‘std’
/usr/local/include/sigslot/signal.hpp:291:32: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:291:66: error: type/value mismatch at argument 2 in template parameter list for ‘template<class T, class> struct sigslot::detail::object_pointer’
291 | struct object_pointer<T*, std::enable_if_t<trait::is_pointer_v<T*>>> {
|                                                                  ^~
/usr/local/include/sigslot/signal.hpp:291:66: note:   expected a type, got ‘(<expression error> < is_pointer_v<T*>)’
/usr/local/include/sigslot/signal.hpp:291:68: error: expected unqualified-id before ‘>’ token
291 | struct object_pointer<T*, std::enable_if_t<trait::is_pointer_v<T*>>> {
|                                                                    ^
/usr/local/include/sigslot/signal.hpp:298:31: error: ‘enable_if_t’ is not a member of ‘std’
298 | struct object_pointer<T, std::enable_if_t<trait::is_weak_ptr_v<T>>> {
|                               ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:298:31: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:298:31: error: ‘enable_if_t’ is not a member of ‘std’
/usr/local/include/sigslot/signal.hpp:298:31: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:298:65: error: type/value mismatch at argument 2 in template parameter list for ‘template<class T, class> struct sigslot::detail::object_pointer’
298 | struct object_pointer<T, std::enable_if_t<trait::is_weak_ptr_v<T>>> {
|                                                                 ^~
/usr/local/include/sigslot/signal.hpp:298:65: note:   expected a type, got ‘(<expression error> < is_weak_ptr_v<T>)’
/usr/local/include/sigslot/signal.hpp:298:67: error: expected unqualified-id before ‘>’ token
298 | struct object_pointer<T, std::enable_if_t<trait::is_weak_ptr_v<T>>> {
|                                                                   ^
/usr/local/include/sigslot/signal.hpp:306:31: error: ‘enable_if_t’ is not a member of ‘std’
306 | struct object_pointer<T, std::enable_if_t<!trait::is_pointer_v<T> &&
|                               ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:306:31: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:306:31: error: ‘enable_if_t’ is not a member of ‘std’
/usr/local/include/sigslot/signal.hpp:306:31: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/local/include/sigslot/signal.hpp:308:76: error: type/value mismatch at argument 2 in template parameter list for ‘template<class T, class> struct sigslot::detail::object_pointer’
308 |                                           trait::is_weak_ptr_compatible_v<T>>>
|                                                                            ^~
/usr/local/include/sigslot/signal.hpp:308:76: note:   expected a type, got ‘(((<expression error> < (! is_pointer_v<T>)) && (! is_weak_ptr_v<T>)) && is_weak_ptr_compatible_v<T>)’
/usr/local/include/sigslot/signal.hpp:308:78: error: expected unqualified-id before ‘>’ token
308 |                                           trait::is_weak_ptr_compatible_v<T>>>
|                                                                              ^
/usr/local/include/sigslot/signal.hpp:398:41: error: ‘std::enable_if_t’ has not been declared
398 |     explicit copy_on_write(U && x, std::enable_if_t<!std::is_same<std::decay_t<U>,
|                                         ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:398:52: error: expected ‘,’ or ‘...’ before ‘<’ token
398 |     explicit copy_on_write(U && x, std::enable_if_t<!std::is_same<std::decay_t<U>,
|                                                    ^
/usr/local/include/sigslot/signal.hpp:532:5: error: ‘index’ function uses ‘auto’ type specifier without trailing return type
532 |     auto index() const {
|     ^~~~
/usr/local/include/sigslot/signal.hpp:532:5: note: deduced return type only available with ‘-std=c++14’ or ‘-std=gnu++14’
/usr/local/include/sigslot/signal.hpp:536:5: error: ‘index’ function uses ‘auto’ type specifier without trailing return type
536 |     auto& index() {
|     ^~~~
/usr/local/include/sigslot/signal.hpp:536:5: note: deduced return type only available with ‘-std=c++14’ or ‘-std=gnu++14’
/usr/local/include/sigslot/signal.hpp:793:10: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
793 |     std::enable_if_t<function_traits<C>::must_check_object, bool>
|          ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:793:5: note: ‘std::enable_if_t’ is only available from C++14 onwards
793 |     std::enable_if_t<function_traits<C>::must_check_object, bool>
|     ^~~
/usr/local/include/sigslot/signal.hpp:799:10: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
799 |     std::enable_if_t<!function_traits<C>::must_check_object, bool>
|          ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:799:5: note: ‘std::enable_if_t’ is only available from C++14 onwards
799 |     std::enable_if_t<!function_traits<C>::must_check_object, bool>
|     ^~~
/usr/local/include/sigslot/signal.hpp:876:10: error: ‘decay_t’ in namespace ‘std’ does not name a template type; did you mean ‘decay’?
876 |     std::decay_t<Func> func;
|          ^~~~~~~
|          decay
/usr/local/include/sigslot/signal.hpp: In constructor ‘constexpr sigslot::detail::slot<Func, Args>::slot(sigslot::detail::cleanable&, F&&, Gid)’:
/usr/local/include/sigslot/signal.hpp:858:11: error: class ‘sigslot::detail::slot<Func, Args>’ does not have any field named ‘func’
858 |         , func{std::forward<F>(f)} {}
|           ^~~~
/usr/local/include/sigslot/signal.hpp: In member function ‘sigslot::detail::func_ptr sigslot::detail::slot<Func, Args>::get_callable() const’:
/usr/local/include/sigslot/signal.hpp:866:33: error: ‘func’ was not declared in this scope; did you mean ‘Func’?
866 |         return get_function_ptr(func);
|                                 ^~~~
|                                 Func
/usr/local/include/sigslot/signal.hpp: In member function ‘const std::type_info& sigslot::detail::slot<Func, Args>::get_callable_type() const’:
/usr/local/include/sigslot/signal.hpp:871:23: error: ‘func’ was not declared in this scope; did you mean ‘Func’?
871 |         return typeid(func);
|                       ^~~~
|                       Func
/usr/local/include/sigslot/signal.hpp: At global scope:
/usr/local/include/sigslot/signal.hpp:908:10: error: ‘decay_t’ in namespace ‘std’ does not name a template type; did you mean ‘decay’?
908 |     std::decay_t<Func> func;
|          ^~~~~~~
|          decay
/usr/local/include/sigslot/signal.hpp: In constructor ‘constexpr sigslot::detail::slot_extended<Func, Args>::slot_extended(sigslot::detail::cleanable&, F&&, sigslot::group_id)’:
/usr/local/include/sigslot/signal.hpp:888:11: error: class ‘sigslot::detail::slot_extended<Func, Args>’ does not have any field named ‘func’
888 |         , func{std::forward<F>(f)} {}
|           ^~~~
/usr/local/include/sigslot/signal.hpp: In member function ‘sigslot::detail::func_ptr sigslot::detail::slot_extended<Func, Args>::get_callable() const’:
/usr/local/include/sigslot/signal.hpp:898:33: error: ‘func’ was not declared in this scope; did you mean ‘Func’?
898 |         return get_function_ptr(func);
|                                 ^~~~
|                                 Func
/usr/local/include/sigslot/signal.hpp: In member function ‘const std::type_info& sigslot::detail::slot_extended<Func, Args>::get_callable_type() const’:
/usr/local/include/sigslot/signal.hpp:903:23: error: ‘func’ was not declared in this scope; did you mean ‘Func’?
903 |         return typeid(func);
|                       ^~~~
|                       Func
/usr/local/include/sigslot/signal.hpp: At global scope:
/usr/local/include/sigslot/signal.hpp:945:10: error: ‘decay_t’ in namespace ‘std’ does not name a template type; did you mean ‘decay’?
945 |     std::decay_t<Pmf> pmf;
|          ^~~~~~~
|          decay
/usr/local/include/sigslot/signal.hpp:946:10: error: ‘decay_t’ in namespace ‘std’ does not name a template type; did you mean ‘decay’?
946 |     std::decay_t<Ptr> ptr;
|          ^~~~~~~
|          decay
/usr/local/include/sigslot/signal.hpp: In constructor ‘constexpr sigslot::detail::slot_pmf<Pmf, Ptr, Args>::slot_pmf(sigslot::detail::cleanable&, F&&, P&&, sigslot::group_id)’:
/usr/local/include/sigslot/signal.hpp:922:11: error: class ‘sigslot::detail::slot_pmf<Pmf, Ptr, Args>’ does not have any field named ‘pmf’
922 |         , pmf{std::forward<F>(f)}
|           ^~~
/usr/local/include/sigslot/signal.hpp:923:11: error: class ‘sigslot::detail::slot_pmf<Pmf, Ptr, Args>’ does not have any field named ‘ptr’
923 |         , ptr{std::forward<P>(p)} {}
|           ^~~
/usr/local/include/sigslot/signal.hpp: In member function ‘void sigslot::detail::slot_pmf<Pmf, Ptr, Args>::call_slot(Args ...)’:
/usr/local/include/sigslot/signal.hpp:927:12: error: ‘ptr’ was not declared in this scope; did you mean ‘Ptr’?
927 |         ((*ptr).*pmf)(args...);
|            ^~~
|            Ptr
/usr/local/include/sigslot/signal.hpp:927:18: error: ‘pmf’ was not declared in this scope; did you mean ‘Pmf’?
927 |         ((*ptr).*pmf)(args...);
|                  ^~~
|                  Pmf
/usr/local/include/sigslot/signal.hpp: In member function ‘sigslot::detail::func_ptr sigslot::detail::slot_pmf<Pmf, Ptr, Args>::get_callable() const’:
/usr/local/include/sigslot/signal.hpp:931:33: error: ‘pmf’ was not declared in this scope; did you mean ‘Pmf’?
931 |         return get_function_ptr(pmf);
|                                 ^~~
|                                 Pmf
/usr/local/include/sigslot/signal.hpp: In member function ‘const void* sigslot::detail::slot_pmf<Pmf, Ptr, Args>::get_object() const’:
/usr/local/include/sigslot/signal.hpp:935:31: error: ‘ptr’ was not declared in this scope; did you mean ‘Ptr’?
935 |         return get_object_ptr(ptr);
|                               ^~~
|                               Ptr
/usr/local/include/sigslot/signal.hpp: In member function ‘const std::type_info& sigslot::detail::slot_pmf<Pmf, Ptr, Args>::get_callable_type() const’:
/usr/local/include/sigslot/signal.hpp:940:23: error: ‘pmf’ was not declared in this scope; did you mean ‘Pmf’?
940 |         return typeid(pmf);
|                       ^~~
|                       Pmf
/usr/local/include/sigslot/signal.hpp: At global scope:
/usr/local/include/sigslot/signal.hpp:982:10: error: ‘decay_t’ in namespace ‘std’ does not name a template type; did you mean ‘decay’?
982 |     std::decay_t<Pmf> pmf;
|          ^~~~~~~
|          decay
/usr/local/include/sigslot/signal.hpp:983:10: error: ‘decay_t’ in namespace ‘std’ does not name a template type; did you mean ‘decay’?
983 |     std::decay_t<Ptr> ptr;
|          ^~~~~~~
|          decay
/usr/local/include/sigslot/signal.hpp: In constructor ‘constexpr sigslot::detail::slot_pmf_extended<Pmf, Ptr, Args>::slot_pmf_extended(sigslot::detail::cleanable&, F&&, P&&, sigslot::group_id)’:
/usr/local/include/sigslot/signal.hpp:958:11: error: class ‘sigslot::detail::slot_pmf_extended<Pmf, Ptr, Args>’ does not have any field named ‘pmf’
958 |         , pmf{std::forward<F>(f)}
|           ^~~
/usr/local/include/sigslot/signal.hpp:959:11: error: class ‘sigslot::detail::slot_pmf_extended<Pmf, Ptr, Args>’ does not have any field named ‘ptr’
959 |         , ptr{std::forward<P>(p)} {}
|           ^~~
/usr/local/include/sigslot/signal.hpp: In member function ‘void sigslot::detail::slot_pmf_extended<Pmf, Ptr, Args>::call_slot(Args ...)’:
/usr/local/include/sigslot/signal.hpp:965:12: error: ‘ptr’ was not declared in this scope; did you mean ‘Ptr’?
965 |         ((*ptr).*pmf)(conn, args...);
|            ^~~
|            Ptr
/usr/local/include/sigslot/signal.hpp:965:18: error: ‘pmf’ was not declared in this scope; did you mean ‘Pmf’?
965 |         ((*ptr).*pmf)(conn, args...);
|                  ^~~
|                  Pmf
/usr/local/include/sigslot/signal.hpp: In member function ‘sigslot::detail::func_ptr sigslot::detail::slot_pmf_extended<Pmf, Ptr, Args>::get_callable() const’:
/usr/local/include/sigslot/signal.hpp:969:33: error: ‘pmf’ was not declared in this scope; did you mean ‘Pmf’?
969 |         return get_function_ptr(pmf);
|                                 ^~~
|                                 Pmf
/usr/local/include/sigslot/signal.hpp: In member function ‘const void* sigslot::detail::slot_pmf_extended<Pmf, Ptr, Args>::get_object() const’:
/usr/local/include/sigslot/signal.hpp:972:31: error: ‘ptr’ was not declared in this scope; did you mean ‘Ptr’?
972 |         return get_object_ptr(ptr);
|                               ^~~
|                               Ptr
/usr/local/include/sigslot/signal.hpp: In member function ‘const std::type_info& sigslot::detail::slot_pmf_extended<Pmf, Ptr, Args>::get_callable_type() const’:
/usr/local/include/sigslot/signal.hpp:977:23: error: ‘pmf’ was not declared in this scope; did you mean ‘Pmf’?
977 |         return typeid(pmf);
|                       ^~~
|                       Pmf
/usr/local/include/sigslot/signal.hpp: At global scope:
/usr/local/include/sigslot/signal.hpp:1032:10: error: ‘decay_t’ in namespace ‘std’ does not name a template type; did you mean ‘decay’?
1032 |     std::decay_t<Func> func;
|          ^~~~~~~
|          decay
/usr/local/include/sigslot/signal.hpp:1033:10: error: ‘decay_t’ in namespace ‘std’ does not name a template type; did you mean ‘decay’?
1033 |     std::decay_t<WeakPtr> ptr;
|          ^~~~~~~
|          decay
/usr/local/include/sigslot/signal.hpp: In constructor ‘constexpr sigslot::detail::slot_tracked<Func, WeakPtr, Args>::slot_tracked(sigslot::detail::cleanable&, F&&, P&&, sigslot::group_id)’:
/usr/local/include/sigslot/signal.hpp:997:11: error: class ‘sigslot::detail::slot_tracked<Func, WeakPtr, Args>’ does not have any field named ‘func’
997 |         , func{std::forward<F>(f)}
|           ^~~~
/usr/local/include/sigslot/signal.hpp:998:11: error: class ‘sigslot::detail::slot_tracked<Func, WeakPtr, Args>’ does not have any field named ‘ptr’
998 |         , ptr{std::forward<P>(p)}
|           ^~~
/usr/local/include/sigslot/signal.hpp: In member function ‘bool sigslot::detail::slot_tracked<Func, WeakPtr, Args>::connected() const’:
/usr/local/include/sigslot/signal.hpp:1002:17: error: ‘ptr’ was not declared in this scope
1002 |         return !ptr.expired() && slot_state::connected();
|                 ^~~
/usr/local/include/sigslot/signal.hpp: In member function ‘void sigslot::detail::slot_tracked<Func, WeakPtr, Args>::call_slot(Args ...)’:
/usr/local/include/sigslot/signal.hpp:1007:19: error: ‘ptr’ was not declared in this scope
1007 |         auto sp = ptr.lock();
|                   ^~~
/usr/local/include/sigslot/signal.hpp: In member function ‘sigslot::detail::func_ptr sigslot::detail::slot_tracked<Func, WeakPtr, Args>::get_callable() const’:
/usr/local/include/sigslot/signal.hpp:1018:33: error: ‘func’ was not declared in this scope; did you mean ‘Func’?
1018 |         return get_function_ptr(func);
|                                 ^~~~
|                                 Func
/usr/local/include/sigslot/signal.hpp: In member function ‘const void* sigslot::detail::slot_tracked<Func, WeakPtr, Args>::get_object() const’:
/usr/local/include/sigslot/signal.hpp:1022:31: error: ‘ptr’ was not declared in this scope
1022 |         return get_object_ptr(ptr);
|                               ^~~
/usr/local/include/sigslot/signal.hpp: In member function ‘const std::type_info& sigslot::detail::slot_tracked<Func, WeakPtr, Args>::get_callable_type() const’:
/usr/local/include/sigslot/signal.hpp:1027:23: error: ‘func’ was not declared in this scope; did you mean ‘Func’?
1027 |         return typeid(func);
|                       ^~~~
|                       Func
/usr/local/include/sigslot/signal.hpp: At global scope:
/usr/local/include/sigslot/signal.hpp:1082:10: error: ‘decay_t’ in namespace ‘std’ does not name a template type; did you mean ‘decay’?
1082 |     std::decay_t<Pmf> pmf;
|          ^~~~~~~
|          decay
/usr/local/include/sigslot/signal.hpp:1083:10: error: ‘decay_t’ in namespace ‘std’ does not name a template type; did you mean ‘decay’?
1083 |     std::decay_t<WeakPtr> ptr;
|          ^~~~~~~
|          decay
/usr/local/include/sigslot/signal.hpp: In constructor ‘constexpr sigslot::detail::slot_pmf_tracked<Pmf, WeakPtr, Args>::slot_pmf_tracked(sigslot::detail::cleanable&, F&&, P&&, sigslot::group_id)’:
/usr/local/include/sigslot/signal.hpp:1047:11: error: class ‘sigslot::detail::slot_pmf_tracked<Pmf, WeakPtr, Args>’ does not have any field named ‘pmf’
1047 |         , pmf{std::forward<F>(f)}
|           ^~~
/usr/local/include/sigslot/signal.hpp:1048:11: error: class ‘sigslot::detail::slot_pmf_tracked<Pmf, WeakPtr, Args>’ does not have any field named ‘ptr’
1048 |         , ptr{std::forward<P>(p)}
|           ^~~
/usr/local/include/sigslot/signal.hpp: In member function ‘bool sigslot::detail::slot_pmf_tracked<Pmf, WeakPtr, Args>::connected() const’:
/usr/local/include/sigslot/signal.hpp:1052:17: error: ‘ptr’ was not declared in this scope
1052 |         return !ptr.expired() && slot_state::connected();
|                 ^~~
/usr/local/include/sigslot/signal.hpp: In member function ‘void sigslot::detail::slot_pmf_tracked<Pmf, WeakPtr, Args>::call_slot(Args ...)’:
/usr/local/include/sigslot/signal.hpp:1057:19: error: ‘ptr’ was not declared in this scope
1057 |         auto sp = ptr.lock();
|                   ^~~
/usr/local/include/sigslot/signal.hpp:1063:21: error: ‘pmf’ was not declared in this scope; did you mean ‘Pmf’?
1063 |             ((*sp).*pmf)(args...);
|                     ^~~
|                     Pmf
/usr/local/include/sigslot/signal.hpp: In member function ‘sigslot::detail::func_ptr sigslot::detail::slot_pmf_tracked<Pmf, WeakPtr, Args>::get_callable() const’:
/usr/local/include/sigslot/signal.hpp:1068:33: error: ‘pmf’ was not declared in this scope; did you mean ‘Pmf’?
1068 |         return get_function_ptr(pmf);
|                                 ^~~
|                                 Pmf
/usr/local/include/sigslot/signal.hpp: In member function ‘const void* sigslot::detail::slot_pmf_tracked<Pmf, WeakPtr, Args>::get_object() const’:
/usr/local/include/sigslot/signal.hpp:1072:31: error: ‘ptr’ was not declared in this scope
1072 |         return get_object_ptr(ptr);
|                               ^~~
/usr/local/include/sigslot/signal.hpp: In member function ‘const std::type_info& sigslot::detail::slot_pmf_tracked<Pmf, WeakPtr, Args>::get_callable_type() const’:
/usr/local/include/sigslot/signal.hpp:1077:23: error: ‘pmf’ was not declared in this scope; did you mean ‘Pmf’?
1077 |         return typeid(pmf);
|                       ^~~
|                       Pmf
/usr/local/include/sigslot/signal.hpp: At global scope:
/usr/local/include/sigslot/signal.hpp:1115:27: error: ‘conditional_t’ in namespace ‘std’ does not name a template type; did you mean ‘conditional’?
1115 |     using cow_type = std::conditional_t<is_thread_safe<L>::value,
|                           ^~~~~~~~~~~~~
|                           conditional
/usr/local/include/sigslot/signal.hpp:1119:32: error: ‘conditional_t’ in namespace ‘std’ does not name a template type; did you mean ‘conditional’?
1119 |     using cow_copy_type = std::conditional_t<is_thread_safe<L>::value,
|                                ^~~~~~~~~~~~~
|                                conditional
/usr/local/include/sigslot/signal.hpp:1201:10: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
1201 |     std::enable_if_t<trait::is_callable_v<arg_list, Callable>, connection>
|          ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1201:5: note: ‘std::enable_if_t’ is only available from C++14 onwards
1201 |     std::enable_if_t<trait::is_callable_v<arg_list, Callable>, connection>
|     ^~~
/usr/local/include/sigslot/signal.hpp:1221:10: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
1221 |     std::enable_if_t<trait::is_callable_v<ext_arg_list, Callable>, connection>
|          ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1221:5: note: ‘std::enable_if_t’ is only available from C++14 onwards
1221 |     std::enable_if_t<trait::is_callable_v<ext_arg_list, Callable>, connection>
|     ^~~
/usr/local/include/sigslot/signal.hpp:1241:10: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
1241 |     std::enable_if_t<trait::is_callable_v<arg_list, Pmf, Ptr> &&
|          ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1241:5: note: ‘std::enable_if_t’ is only available from C++14 onwards
1241 |     std::enable_if_t<trait::is_callable_v<arg_list, Pmf, Ptr> &&
|     ^~~
/usr/local/include/sigslot/signal.hpp:1261:10: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
1261 |     std::enable_if_t<trait::is_callable_v<arg_list, Pmf, Ptr> &&
|          ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1261:5: note: ‘std::enable_if_t’ is only available from C++14 onwards
1261 |     std::enable_if_t<trait::is_callable_v<arg_list, Pmf, Ptr> &&
|     ^~~
/usr/local/include/sigslot/signal.hpp:1281:10: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
1281 |     std::enable_if_t<trait::is_callable_v<ext_arg_list, Pmf, Ptr> &&
|          ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1281:5: note: ‘std::enable_if_t’ is only available from C++14 onwards
1281 |     std::enable_if_t<trait::is_callable_v<ext_arg_list, Pmf, Ptr> &&
|     ^~~
/usr/local/include/sigslot/signal.hpp:1310:10: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
1310 |     std::enable_if_t<!trait::is_callable_v<arg_list, Pmf> &&
|          ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1310:5: note: ‘std::enable_if_t’ is only available from C++14 onwards
1310 |     std::enable_if_t<!trait::is_callable_v<arg_list, Pmf> &&
|     ^~~
/usr/local/include/sigslot/signal.hpp:1340:10: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
1340 |     std::enable_if_t<trait::is_callable_v<arg_list, Callable> &&
|          ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1340:5: note: ‘std::enable_if_t’ is only available from C++14 onwards
1340 |     std::enable_if_t<trait::is_callable_v<arg_list, Callable> &&
|     ^~~
/usr/local/include/sigslot/signal.hpp:1376:10: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
1376 |     std::enable_if_t<(trait::is_callable_v<arg_list, Callable> ||
|          ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1376:5: note: ‘std::enable_if_t’ is only available from C++14 onwards
1376 |     std::enable_if_t<(trait::is_callable_v<arg_list, Callable> ||
|     ^~~
/usr/local/include/sigslot/signal.hpp:1399:10: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
1399 |     std::enable_if_t<!trait::is_callable_v<arg_list, Obj> &&
|          ^~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1399:5: note: ‘std::enable_if_t’ is only available from C++14 onwards
1399 |     std::enable_if_t<!trait::is_callable_v<arg_list, Obj> &&
|     ^~~
/usr/local/include/sigslot/signal.hpp:1522:12: error: ‘cow_copy_type’ does not name a type
1522 |     inline cow_copy_type<list_type, Lockable> slots_reference() {
|            ^~~~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1529:12: error: ‘make_slot’ function uses ‘auto’ type specifier without trailing return type
1529 |     inline auto make_slot(A && ...a) {
|            ^~~~
/usr/local/include/sigslot/signal.hpp:1529:12: note: deduced return type only available with ‘-std=c++14’ or ‘-std=gnu++14’
/usr/local/include/sigslot/signal.hpp:1589:5: error: ‘cow_type’ does not name a type; did you mean ‘lock_type’?
1589 |     cow_type<list_type, Lockable> m_slots;
|     ^~~~~~~~
|     lock_type
/usr/local/include/sigslot/signal.hpp: In constructor ‘sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >::signal_base(sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >&&)’:
/usr/local/include/sigslot/signal.hpp:1146:14: error: ‘m_slots’ was not declared in this scope
1146 |         swap(m_slots, o.m_slots);
|              ^~~~~~~
/usr/local/include/sigslot/signal.hpp: In member function ‘sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >& sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >::operator=(sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >&&)’:
/usr/local/include/sigslot/signal.hpp:1155:14: error: ‘m_slots’ was not declared in this scope
1155 |         swap(m_slots, o.m_slots);
|              ^~~~~~~
/usr/local/include/sigslot/signal.hpp: In member function ‘void sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >::operator()(U&& ...)’:
/usr/local/include/sigslot/signal.hpp:1180:9: error: ‘cow_copy_type’ was not declared in this scope
1180 |         cow_copy_type<list_type, Lockable> ref = slots_reference();
|         ^~~~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1180:32: error: expected primary-expression before ‘,’ token
1180 |         cow_copy_type<list_type, Lockable> ref = slots_reference();
|                                ^
/usr/local/include/sigslot/signal.hpp:1180:42: error: expected primary-expression before ‘>’ token
1180 |         cow_copy_type<list_type, Lockable> ref = slots_reference();
|                                          ^
/usr/local/include/sigslot/signal.hpp:1180:50: error: there are no arguments to ‘slots_reference’ that depend on a template parameter, so a declaration of ‘slots_reference’ must be available [-fpermissive]
1180 |         cow_copy_type<list_type, Lockable> ref = slots_reference();
|                                                  ^~~~~~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1180:50: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
/usr/local/include/sigslot/signal.hpp:1182:50: error: no matching function for call to ‘cow_read(<unresolved overloaded function type>)’
1182 |         for (const auto &group : detail::cow_read(ref)) {
|                                  ~~~~~~~~~~~~~~~~^~~~~
/usr/local/include/sigslot/signal.hpp:463:10: note: candidate: ‘template<class T> const T& sigslot::detail::cow_read(const T&)’
463 | const T& cow_read(const T &v) {
|          ^~~~~~~~
/usr/local/include/sigslot/signal.hpp:463:10: note:   template argument deduction/substitution failed:
/usr/local/include/sigslot/signal.hpp:1182:50: note:   couldn’t deduce template parameter ‘T’
1182 |         for (const auto &group : detail::cow_read(ref)) {
|                                  ~~~~~~~~~~~~~~~~^~~~~
/usr/local/include/sigslot/signal.hpp:468:10: note: candidate: ‘template<class T> const T& sigslot::detail::cow_read(sigslot::detail::copy_on_write<T>&)’
468 | const T& cow_read(copy_on_write<T> &v) {
|          ^~~~~~~~
/usr/local/include/sigslot/signal.hpp:468:10: note:   template argument deduction/substitution failed:
/usr/local/include/sigslot/signal.hpp:1182:50: note:   couldn’t deduce template parameter ‘T’
1182 |         for (const auto &group : detail::cow_read(ref)) {
|                                  ~~~~~~~~~~~~~~~~^~~~~
/usr/local/include/sigslot/signal.hpp: In member function ‘size_t sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >::disconnect(const Callable&, const Obj&)’:
/usr/local/include/sigslot/signal.hpp:1423:41: error: use of ‘auto’ in lambda parameter declaration only available with ‘-std=c++14’ or ‘-std=gnu++14’
1423 |         return disconnect_if([&] (const auto &s) {
|                                         ^~~~
/usr/local/include/sigslot/signal.hpp: In lambda function:
/usr/local/include/sigslot/signal.hpp:1424:21: error: base operand of ‘->’ is not a pointer
1424 |             return s->has_object(obj) && s->has_callable(c);
|                     ^~
/usr/local/include/sigslot/signal.hpp:1424:43: error: base operand of ‘->’ is not a pointer
1424 |             return s->has_object(obj) && s->has_callable(c);
|                                           ^~
/usr/local/include/sigslot/signal.hpp: In member function ‘size_t sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >::disconnect(sigslot::group_id)’:
/usr/local/include/sigslot/signal.hpp:1439:46: error: ‘m_slots’ was not declared in this scope
1439 |         for (auto &group : detail::cow_write(m_slots)) {
|                                              ^~~~~~~
/usr/local/include/sigslot/signal.hpp: In member function ‘size_t sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >::slot_count()’:
/usr/local/include/sigslot/signal.hpp:1486:9: error: ‘cow_copy_type’ was not declared in this scope
1486 |         cow_copy_type<list_type, Lockable> ref = slots_reference();
|         ^~~~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1486:32: error: expected primary-expression before ‘,’ token
1486 |         cow_copy_type<list_type, Lockable> ref = slots_reference();
|                                ^
/usr/local/include/sigslot/signal.hpp:1486:42: error: expected primary-expression before ‘>’ token
1486 |         cow_copy_type<list_type, Lockable> ref = slots_reference();
|                                          ^
/usr/local/include/sigslot/signal.hpp:1486:50: error: there are no arguments to ‘slots_reference’ that depend on a template parameter, so a declaration of ‘slots_reference’ must be available [-fpermissive]
1486 |         cow_copy_type<list_type, Lockable> ref = slots_reference();
|                                                  ^~~~~~~~~~~~~~~
/usr/local/include/sigslot/signal.hpp:1488:46: error: no matching function for call to ‘cow_read(<unresolved overloaded function type>)’
1488 |         for (const auto &g : detail::cow_read(ref)) {
|                              ~~~~~~~~~~~~~~~~^~~~~
/usr/local/include/sigslot/signal.hpp:463:10: note: candidate: ‘template<class T> const T& sigslot::detail::cow_read(const T&)’
463 | const T& cow_read(const T &v) {
|          ^~~~~~~~
/usr/local/include/sigslot/signal.hpp:463:10: note:   template argument deduction/substitution failed:
/usr/local/include/sigslot/signal.hpp:1488:46: note:   couldn’t deduce template parameter ‘T’
1488 |         for (const auto &g : detail::cow_read(ref)) {
|                              ~~~~~~~~~~~~~~~~^~~~~
/usr/local/include/sigslot/signal.hpp:468:10: note: candidate: ‘template<class T> const T& sigslot::detail::cow_read(sigslot::detail::copy_on_write<T>&)’
468 | const T& cow_read(copy_on_write<T> &v) {
|          ^~~~~~~~
/usr/local/include/sigslot/signal.hpp:468:10: note:   template argument deduction/substitution failed:
/usr/local/include/sigslot/signal.hpp:1488:46: note:   couldn’t deduce template parameter ‘T’
1488 |         for (const auto &g : detail::cow_read(ref)) {
|                              ~~~~~~~~~~~~~~~~^~~~~
/usr/local/include/sigslot/signal.hpp: In member function ‘void sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >::clean(sigslot::detail::slot_state*)’:
/usr/local/include/sigslot/signal.hpp:1504:46: error: ‘m_slots’ was not declared in this scope
1504 |         for (auto &group : detail::cow_write(m_slots)) {
|                                              ^~~~~~~
/usr/local/include/sigslot/signal.hpp: In member function ‘void sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >::add_slot(sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >::slot_ptr&&)’:
/usr/local/include/sigslot/signal.hpp:1538:42: error: ‘m_slots’ was not declared in this scope
1538 |         auto &groups = detail::cow_write(m_slots);
|                                          ^~~~~~~
/usr/local/include/sigslot/signal.hpp: In member function ‘size_t sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >::disconnect_if(Cond&&)’:
/usr/local/include/sigslot/signal.hpp:1560:42: error: ‘m_slots’ was not declared in this scope
1560 |         auto &groups = detail::cow_write(m_slots);
|                                          ^~~~~~~
/usr/local/include/sigslot/signal.hpp: In member function ‘void sigslot::signal_base< <template-parameter-1-1>, <template-parameter-1-2> >::clear()’:
/usr/local/include/sigslot/signal.hpp:1584:27: error: ‘m_slots’ was not declared in this scope
1584 |         detail::cow_write(m_slots).clear();
|                           ^~~~~~~
```