### PR TITLE
fix issue in backend::optimise with map::at()

### DIFF
--- a/ch13/src/backend.cpp
+++ b/ch13/src/backend.cpp
@@ -108,6 +108,11 @@ void Backend::Optimize(Map::KeyframesType &keyframes,
                 optimizer.addVertex(v);
             }
 
+
+            if (vertices.find(frame->keyframe_id_) !=
+                vertices.end() && 
+                vertices_landmarks.find(landmark_id) !=
+                vertices_landmarks.end()) {
             edge->setId(index);
             edge->setVertex(0, vertices.at(frame->keyframe_id_));    // pose
             edge->setVertex(1, vertices_landmarks.at(landmark_id));  // landmark
@@ -117,10 +122,10 @@ void Backend::Optimize(Map::KeyframesType &keyframes,
             rk->setDelta(chi2_th);
             edge->setRobustKernel(rk);
             edges_and_features.insert({edge, feat});
-
             optimizer.addEdge(edge);
-
             index++;
+                }
+                
         }
     }
 

--- a/ch13/src/backend.cpp
+++ b/ch13/src/backend.cpp
@@ -113,18 +113,19 @@ void Backend::Optimize(Map::KeyframesType &keyframes,
                 vertices.end() && 
                 vertices_landmarks.find(landmark_id) !=
                 vertices_landmarks.end()) {
-            edge->setId(index);
-            edge->setVertex(0, vertices.at(frame->keyframe_id_));    // pose
-            edge->setVertex(1, vertices_landmarks.at(landmark_id));  // landmark
-            edge->setMeasurement(toVec2(feat->position_.pt));
-            edge->setInformation(Mat22::Identity());
-            auto rk = new g2o::RobustKernelHuber();
-            rk->setDelta(chi2_th);
-            edge->setRobustKernel(rk);
-            edges_and_features.insert({edge, feat});
-            optimizer.addEdge(edge);
-            index++;
+                    edge->setId(index);
+                    edge->setVertex(0, vertices.at(frame->keyframe_id_));    // pose
+                    edge->setVertex(1, vertices_landmarks.at(landmark_id));  // landmark
+                    edge->setMeasurement(toVec2(feat->position_.pt));
+                    edge->setInformation(Mat22::Identity());
+                    auto rk = new g2o::RobustKernelHuber();
+                    rk->setDelta(chi2_th);
+                    edge->setRobustKernel(rk);
+                    edges_and_features.insert({edge, feat});
+                    optimizer.addEdge(edge);
+                    index++;
                 }
+            else delete edge;
                 
         }
     }


### PR DESCRIPTION
First, thanks for the great work to @gaoxiang12 and all the maintainers.

Found an issue in the backend loop:

If somehow execution is slowed down, std::map::at() throws out of range exception as it is looking for an element in vertices that has not been added yet.

The faulty line is:
`edge->setVertex(0, vertices.at(frame->keyframe_id_));`

This happens because if enough time has passed from when the vertices are assigned with the value from the map, a landmark might be observed by a keyframe that has not been inserted yet in the pose vertices.

To be sure, I added a check on the landmark vertices as well, even if the problem presents itself because of pose vertices.

Steps to replicate: just add some LOG(INFO) 's  right before `edge->setId(index);` to slow down execution intentionally and error should pop up.