### PR TITLE
Update ceresCurveFitting.cpp 处理问题 error: call of overloaded ‘exp(double)’ is ambiguous

### DIFF
--- a/ch6/ceresCurveFitting.cpp
+++ b/ch6/ceresCurveFitting.cpp
@@ -1,7 +1,7 @@
 //
 // Created by xiang on 18-11-19.
 //
-
+#include <cmath>
 #include <iostream>
 #include <opencv2/core/core.hpp>
 #include <ceres/ceres.h>
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
   for (int i = 0; i < N; i++) {
     double x = i / 100.0;
     x_data.push_back(x);
-    y_data.push_back(exp(ar * x * x + br * x + cr) + rng.gaussian(w_sigma * w_sigma));
+    y_data.push_back(std::exp(ar * x * x + br * x + cr) + rng.gaussian(w_sigma * w_sigma));
   }
 
   double abc[3] = {ae, be, ce};


### PR DESCRIPTION
如果不加上std::exp,那么在ceres库里也有这个函数，将会导致二义性 error: call of overloaded ‘exp(double)’ is ambiguous